### PR TITLE
global: refactor how plugins get run energy from the client

### DIFF
--- a/ElAstrals/ElAstrals.gradle.kts
+++ b/ElAstrals/ElAstrals.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "2.1.1"
+version = "2.1.2"
 
 project.extra["PluginName"] = "El Astrals" // This is the name that is used in the external plugin manager panel
 project.extra["PluginDescription"] = "Crafts astrals for you" // This is the description that is used in the external plugin manager panel

--- a/ElAstrals/src/main/java/net/runelite/client/plugins/ElAstrals/ElAstralsPlugin.java
+++ b/ElAstrals/src/main/java/net/runelite/client/plugins/ElAstrals/ElAstralsPlugin.java
@@ -593,7 +593,7 @@ public class ElAstralsPlugin extends Plugin
 	private int checkRunEnergy()
 	{
 		try{
-			return Integer.parseInt(client.getWidget(160,23).getText());
+			return client.getEnergy();
 		} catch (Exception ignored) {
 
 		}

--- a/ElCosmics/src/main/java/net/runelite/client/plugins/ElCosmics/ElCosmicsPlugin.java
+++ b/ElCosmics/src/main/java/net/runelite/client/plugins/ElCosmics/ElCosmicsPlugin.java
@@ -564,7 +564,7 @@ public class ElCosmicsPlugin extends Plugin
 	private int checkRunEnergy()
 	{
 		try{
-			return Integer.parseInt(client.getWidget(160,23).getText());
+			return client.getEnergy();
 		} catch (Exception ignored) {
 
 		}

--- a/ElHunter/ElHunter.gradle.kts
+++ b/ElHunter/ElHunter.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "2.0.0"
+version = "2.0.1"
 
 project.extra["PluginName"] = "El Hunter" // This is the name that is used in the external plugin manager panel
 project.extra["PluginDescription"] = "Hunts for you" // This is the description that is used in the external plugin manager panel

--- a/ElHunter/src/main/java/net/runelite/client/plugins/ElHunter/ElHunterPlugin.java
+++ b/ElHunter/src/main/java/net/runelite/client/plugins/ElHunter/ElHunterPlugin.java
@@ -270,7 +270,7 @@ public class ElHunterPlugin extends Plugin
 	private int checkRunEnergy()
 	{
 		try{
-			return Integer.parseInt(client.getWidget(160,23).getText());
+			return client.getEnergy();
 		} catch (Exception ignored) {
 
 		}

--- a/ElTest/ElTest.gradle.kts
+++ b/ElTest/ElTest.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "2.0.0"
+version = "2.0.1"
 
 project.extra["PluginName"] = "El Test" // This is the name that is used in the external plugin manager panel
 project.extra["PluginDescription"] = "Test plugin" // This is the description that is used in the external plugin manager panel

--- a/ElTest/src/main/java/net/runelite/client/plugins/ElTest/ElTestPlugin.java
+++ b/ElTest/src/main/java/net/runelite/client/plugins/ElTest/ElTestPlugin.java
@@ -528,7 +528,7 @@ public class ElTestPlugin extends Plugin implements MouseListener, KeyListener {
 	private int checkRunEnergy()
 	{
 		try{
-			return Integer.parseInt(client.getWidget(160,23).getText());
+			return client.getEnergy();
 		} catch (Exception ignored) {
 
 		}

--- a/ElZMI/ElZMI.gradle.kts
+++ b/ElZMI/ElZMI.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "2.0.1"
+version = "2.0.2"
 
 project.extra["PluginName"] = "El ZMI" // This is the name that is used in the external plugin manager panel
 project.extra["PluginDescription"] = "Crafts runes for you" // This is the description that is used in the external plugin manager panel

--- a/ElZMI/src/main/java/net/runelite/client/plugins/ElZMI/ElZMIPlugin.java
+++ b/ElZMI/src/main/java/net/runelite/client/plugins/ElZMI/ElZMIPlugin.java
@@ -579,7 +579,7 @@ public class ElZMIPlugin extends Plugin
 	private int checkRunEnergy()
 	{
 		try{
-			return Integer.parseInt(client.getWidget(160,23).getText());
+			return client.getEnergy();
 		} catch (Exception ignored) {
 
 		}


### PR DESCRIPTION
Fixes a bug when a user has their run energy converted to seconds from the Status Orb plugin